### PR TITLE
fix productionweight always equaling revenueweight

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ RunMode parseOptions(int argc, const char** argv, ProbeOptimizer& optimizer)
     optimizer.setSetupInput(vm["setup"].as<std::string>());
     optimizer.setStorageWeight(vm["storageweight"].as<float>());
     optimizer.setRevenueWeight(vm["revenueweight"].as<float>());
-    optimizer.setProductionWeight(vm["revenueweight"].as<float>());
+    optimizer.setProductionWeight(vm["productionweight"].as<float>());
     optimizer.setMaxIterations(vm["iterations"].as<size_t>());
     optimizer.setNumOffsprings(vm["offsprings"].as<size_t>());
     optimizer.setMutationRate(vm["mutation"].as<float>());


### PR DESCRIPTION
Production weight would always take the value of revenue weight regardless of user setting as they used the same variable